### PR TITLE
Update environment.yml and ext/dfe_alpha_makefile_stdpopsim_patch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: analysis2
 channels:
   - conda-forge
+  - bioconda
 dependencies:
   - python==3.8
   - pip
@@ -17,6 +18,7 @@ dependencies:
   - cython
   - tqdm
   - h5py
+  - gfortran
   - blas
   - gsl
   - dadi

--- a/ext/dfe_alpha_makefile_stdpopsim_patch
+++ b/ext/dfe_alpha_makefile_stdpopsim_patch
@@ -1,7 +1,5 @@
-GSLDIR = ${CONDA_PREFIX}
-
-CC        = gcc
-CFLAGS   += -lm -lgsl -lgslcblas -O4 -I${GSLDIR}/include -L${GSLDIR}/lib
+CC        = ${CONDA_PREFIX}/bin/gcc
+CFLAGS   += -lm -lgsl -lgslcblas -O4 -fcommon -I${CONDA_PREFIX}/include -L${CONDA_PREFIX}/lib 
 
 all: est_dfe est_alpha_omega prop_muts_in_s_ranges
        


### PR DESCRIPTION
In this pr,

I updated `environment.yml` by adding the `bioconda` channel, because `snakemake` is in the `bioconda` channel (https://anaconda.org/bioconda/snakemake).

I also updated `ext/dfe_alpha_makefile_stdpopsim_patch` by adding `-fcommon` in CFLAGS, because GCC 10 defaults to `-fno-common` (https://gcc.gnu.org/gcc-10/porting_to.html) and causes multiple definitions error.