### PR TITLE
Patch sp plot

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -11,7 +11,7 @@ Parameters are defined by the config.yaml file in
 workflows/config/snakemake/
 """
 
-configfile: "workflows/config/snakemake/tiny_config.yaml"
+configfile: "workflows/config/snakemake/config.yaml"
 
 
 module simulation_workflow:

--- a/workflows/config/snakemake/config.yaml
+++ b/workflows/config/snakemake/config.yaml
@@ -1,13 +1,16 @@
 "seed": 12345
 "population_id": 0
 "num_samples_per_population": [10, 10, 10]
-"replicates": 1
+"replicates": 3
 
 "species": "HomSap"
 
 "demo_models":
     [
-        { "id": "Constant", "num_samples_per_population": [10] },
+        { 
+            "id": "Constant", 
+            "num_samples_per_population": [10],
+        },
         {
             "id": "OutOfAfrica_3G09",
             "num_samples_per_population": [10, 10, 10],
@@ -21,19 +24,18 @@
 "mask_file": "workflows/masks/HapmapII_GRCh37.mask.bed"
 
 # slim settings
-"slim_scaling_factor": 15
+"slim_scaling_factor": 10
 "slim_burn_in": 10
 
 # n(t) specific configs
 
 "num_sampled_genomes_msmc": [2]
 "num_sampled_genomes_per_replicate": [2]
-"num_msmc_iterations": 1
+"num_msmc_iterations": 3
 
 "annotation_list": ["ensembl_havana_104_exons"]
 "gone_phase": 1 # 0 for pseudohaploid, 1 for unknown phase, 2 for phased
-"gone_max_snps": 500 # default=50000
-"gone_threads": 1
+"gone_max_snps": 50000 # default=50000
 "gone_num_gens": 2000 # default=2000
 "gone_num_bins": 400 # default=400
 

--- a/workflows/config/snakemake/oregon_profile/config.yaml
+++ b/workflows/config/snakemake/oregon_profile/config.yaml
@@ -10,7 +10,7 @@ cluster:
                 --output=logs/{rule}/{rule}-{wildcards}-%j.out
 default-resources:
         - time=60
-        - mem_mb=5000
+        - mem_mb=12000
         - threads=1
 restart-times: 3
 max-jobs-per-second: 10

--- a/workflows/gone.py
+++ b/workflows/gone.py
@@ -15,10 +15,10 @@ def params(gone_code,params):
     with open(gone_code+"/INPUT_PARAMETERS_FILE") as params_file: text=params_file.readlines()
     text[4]=text[4].replace("PHASE=2","PHASE="+str(params['gone_phase']))
     text[7]=text[7].replace("NGEN=2000","NGEN="+str(params['gone_num_gens']))
-    text[8]=text[8].replace("NBIN=4002","NBIN="+str(params['gone_num_bins']))
+    text[8]=text[8].replace("NBIN=400","NBIN="+str(params['gone_num_bins']))
     text[12]=text[12].replace("maxNSNP=50000","maxNSNP="+str(params['gone_max_snps']))
-    text[15]=text[15].replace("threads=-99","threads="+str(params['gone_threads']))
-    with open(gone_code+"/INPUT_PARAMETERS_FILE","w") as params_file: 
+    # text[15]=text[15].replace("threads=-99","threads="+str(params['gone_threads']))
+    with open(gone_code+"/INPUT_PARAMETERS_FILE_TMP","w") as params_file: 
         for line in text:
             params_file.write(line)
 
@@ -30,7 +30,7 @@ def params(gone_code,params):
 
 def copy(gone_code,outpath,seed,threads):
     cwd = os.getcwd()
-    cmd =  "".join(["ln -sf ",cwd,"/",gone_code,"/INPUT_PARAMETERS_FILE ",
+    cmd =  "".join(["ln -sf ",cwd,"/",gone_code,"/INPUT_PARAMETERS_FILE_TMP ",
                     outpath,"/INPUT_PARAMETERS_FILE;\n\n"])
     cmd += "".join(["cat " + gone_code + "/script_GONE.sh | sed s/\"num=\$RANDOM\"/\"RANDOM=", seed,"\\nnum=\$RANDOM\"/g > ", outpath, "/script_GONE.sh;\n\n"])
     cmd += "".join(["mkdir ", outpath, "/PROGRAMMES;\n\n"])

--- a/workflows/n_t.snake
+++ b/workflows/n_t.snake
@@ -31,7 +31,7 @@ import masks
 # A seed to replicate results
 # TODO mutation rates
 
-configfile: "workflows/config/snakemake/tiny_config.yaml"
+configfile: "workflows/config/snakemake/config.yaml"
 
 np.random.seed(config["seed"])
 output_dir = os.path.abspath(config["output_dir"])
@@ -117,6 +117,17 @@ try:
 except KeyError:
     mask_file = None
 
+localrules:  
+    download_genetic_map,
+    download_msmc,
+    sp_download,
+    clone_smcpp,
+    gone_clone,
+    gone_copy,
+    gone_params,
+    all_plot
+
+
 rule all:
    input: 
     expand(output_dir + "/plots/{demog}/{chrms}/{dfes}/{annots}/all_estimated_Ne.pdf", 
@@ -180,13 +191,14 @@ rule run_stairwayplot:
         rules.sp_download.output,
     output: output_dir + "/inference/sp/{demog}/{dfes}/{annots}/{seeds}/{chrms}/stairwayplot_estimated_Ne.txt"
     threads: 20
+    resources: mem_mb=120000
     run:
         inputs = expand(output_dir + "/simulated_data/{demog}/{dfes}/{annots}/{seeds}/sim_{chrms}.trees",
-            seeds=seed_array,
-            chrms=chrm_list,
-            dfes=dfe_list,
-            demog=demo_model_ids,
-            annots=annotation_list,
+        seeds=wildcards.seeds,
+        chrms=chrm_list,
+        dfes=wildcards.dfes,
+        demog=wildcards.demog,
+        annots=wildcards.annots,
             )
         # fix here to be able to run a list of selection items in one goal
         runner = stairway.StairwayPlotRunner(
@@ -208,9 +220,9 @@ def ne_files_sp(wildcards):
     return expand(output_dir + "/inference/sp/{demog}/{dfes}/{annots}/{seeds}/{chrms}/stairwayplot_estimated_Ne.txt",
         seeds=seed_array,
         chrms=chrm_list,
-        dfes=dfe_list,
-        demog=demo_model_ids,
-        annots=annotation_list,
+        dfes=wildcards.dfes,
+        demog=wildcards.demog,
+        annots=wildcards.annots,
     )
 
 
@@ -416,7 +428,7 @@ rule gone_clone:
         directory("ext/GONE")
     message:
         "cloning GONE repo"
-    threads: 20
+    threads: 1
     shell:
         """
         cd ext/
@@ -432,11 +444,10 @@ rule gone_params:
         ".params_edited"
     message:
         "specifying GONE params"
-    threads: 20
+    threads: 1
     run:
         prms = {"gone_phase":config["gone_phase"],
                 "gone_max_snps":config["gone_max_snps"],
-                "gone_threads":config["gone_threads"],
                 "gone_num_gens":config["gone_num_gens"],
                 "gone_num_bins":config["gone_num_bins"]}
         gone.params(gone_code, prms)
@@ -451,7 +462,7 @@ rule gone_copy:
         output_dir + "/inference/gone/{demog}/{dfes}/{annots}/{seeds}/{chrms}/.scripts_copied"
     message:
         "copying GONE scripts into individual working directories"
-    threads: 20
+    threads: 1
     run:
         print(output[0])
         outpath = "/".join(output[0].split("/")[:-1])
@@ -464,7 +475,7 @@ rule gone_prep_inputs:
     output:
         output_dir + "/inference/gone/{demog}/{dfes}/{annots}/{seeds}/{chrms}/gone.ped",
         output_dir + "/inference/gone/{demog}/{dfes}/{annots}/{seeds}/{chrms}/gone.map",
-    threads: 20
+    threads: 1
     run:
         genetic_map = species.get_genetic_map(genetic_map_id)
         if not genetic_map.is_cached():
@@ -485,7 +496,8 @@ rule gone_run:
         rules.gone_prep_inputs.output,
     output:
         output_dir + "/inference/gone/{demog}/{dfes}/{annots}/{seeds}/{chrms}/Output_Ne_gone",
-    threads: 20
+    threads: 8
+    resources: time=180
     shell:
         """
         cwd=$PWD

--- a/workflows/plots.py
+++ b/workflows/plots.py
@@ -119,6 +119,7 @@ def plot_all_ne_estimates(sp_infiles, msmc_infiles, gone_infiles, outfile,
     for i, infile in enumerate(sp_infiles):
         nt = pd.read_csv(infile, sep="\t", skiprows=5)
         line2, = ax[0].plot(nt['year'], nt['Ne_median'], alpha=0.8)
+
         for j in range(0, len(nt["year"]), 2):
             outLines.append([nt["year"][j], nt["Ne_median"]
                             [j], "sp", "r" + str(i + 1)])

--- a/workflows/simulation.snake
+++ b/workflows/simulation.snake
@@ -46,7 +46,6 @@ annotation_list = config["annotation_list"]
 # ###############################################################################
 # GENERAL RULES & GLOBALS
 # ###############################################################################
-
 rule all:
     input:
         expand(output_dir + "/simulated_data/{demog}/{dfes}/{annots}/{seeds}/sim_{chrms}.trees", 
@@ -63,7 +62,6 @@ rule simulation:
         output_dir + "/simulated_data/{demog}/{dfes}/{annots}/{seeds}/sim_{chrms}.trees"
     resources: time=3000, mem_mb=10000
     run:
-        
         if wildcards.demog == 'Constant': 
             model = stdpopsim.PiecewiseConstantSize(species.population_size)
             mutation_rate = 1.29e-08 # where is this from?


### PR DESCRIPTION
here is a patch for the bug that @lntran26 found and reported in #71, which appeared to be an issue with ploting stairwayplot results. 

In examining things, what was happening was that a helper function being used to expand the list of file names with stairwayplot results to plot was expanding over too many wildcards, and so inappropriate reps (e.g. between demographies) were being plotting together.

this PR provides a fix for this bug that will close #71