### PR TITLE
added samples with size to dict for SLiM input deprecation warning

### DIFF
--- a/workflows/simulation.snake
+++ b/workflows/simulation.snake
@@ -6,7 +6,7 @@ import os
 import numpy as np
 import stdpopsim
 
-configfile: "workflows/config/snakemake/config.yaml"
+configfile: "workflows/config/snakemake/tiny_config.yaml"
 
 np.random.seed(config["seed"])
 
@@ -48,13 +48,13 @@ annotation_list = config["annotation_list"]
 # ###############################################################################
 rule all:
     input:
-        expand(output_dir + "/simulated_data/{demog}/{dfes}/{annots}/{seeds}/sim_{chrms}.trees", 
-            seeds=seed_array, 
+        expand(
+            [output_dir + "/simulated_data/{{demog}}/{dfes}/{annots}/{{seeds}}/sim_{{chrms}}.trees".format(
+                dfes=DFE, annots=ANNOT) for (DFE, ANNOT) in zip(dfe_list, annotation_list)],
             demog=demo_model_ids,
-            dfes=dfe_list,
-            annots=annotation_list,
-            chrms=chrm_list
-            )
+            seeds=seed_array,
+            chrms=chrm_list,
+        ),
 
 rule simulation:
     input:
@@ -65,12 +65,12 @@ rule simulation:
         if wildcards.demog == 'Constant': 
             model = stdpopsim.PiecewiseConstantSize(species.population_size)
             mutation_rate = 1.29e-08 # where is this from?
-            samples = model.get_samples(*demo_sample_size_dict[wildcards.demog])
+            #samples = model.get_samples(*demo_sample_size_dict[wildcards.demog])
         else: 
             model = species.get_demographic_model(wildcards.demog)
             mutation_rate = model.mutation_rate
-            samples = model.get_samples(*demo_sample_size_dict[wildcards.demog])  # YRI, CEU, CHB
-
+            #samples = model.get_samples(*demo_sample_size_dict[wildcards.demog])  # YRI, CEU, CHB
+        samples = {f"{model.populations[i].name}": m for i, m in enumerate(demo_sample_size_dict[wildcards.demog])}
         genetic_map_id = config["genetic_map"]
         contig = species.get_contig(wildcards.chrms, genetic_map=genetic_map_id)
         if wildcards.dfes != "none":


### PR DESCRIPTION
Warning of deprecation error where previous input was vector of pop sizes. Now build dict from stdpopsim model w/ popsizes and pop names