### PR TITLE
Msmc parallel

### DIFF
--- a/workflows/msmc.py
+++ b/workflows/msmc.py
@@ -71,7 +71,7 @@ def write_msmc_file(path, output, pop_name, mask_intervals=None):
     return None
 
 
-def run_msmc_estimate(input_files, output_file, msmc_exec_loc, total_samples, num_genomes, iterations=1, ncores=1):
+def run_msmc_estimate(input_files, output_file, num_genomes, msmc_exec_loc, total_samples, iterations=1, ncores=1):
     """
     This is to run the msmc command and get estimates,
     It then will convert the scales times and pop sizes
@@ -80,17 +80,12 @@ def run_msmc_estimate(input_files, output_file, msmc_exec_loc, total_samples, nu
     The final estimates will be written to
     input_file.final.txt
     """
-    # TODO: change here, to num_samples and drop loop, if get wildcards.samps sorted in n_t.smk
-    assert max(num_genomes) < total_samples * 2
-    for nsamps in num_genomes:
-        subset = np.random.choice(range(total_samples*2), nsamps, replace=False)
-        haplotypes = ",".join(map(str, sorted(subset)))
-        cmd = (f"{msmc_exec_loc} -r 0.25 -I {haplotypes} -i {iterations} -o {output_file}{nsamps}.trees.multihep.txt -t {ncores} {input_files}")
-        try:
-            subprocess.run(cmd, shell=True, check=True)
-        except subprocess.CalledProcessError as e:
-            print(e.output)
-            subprocess.run(cmd, shell=True, check=True)
+    num_genomes = int(num_genomes)
+    assert num_genomes < total_samples * 2
+    subset = np.random.choice(range(total_samples*2), num_genomes, replace=False)
+    haplotypes = ",".join(map(str, sorted(subset)))
+    cmd = (f"{msmc_exec_loc} -r 0.25 -I {haplotypes} -i {iterations} -o {output_file}{num_genomes}.trees.multihep.txt -t {ncores} {input_files}")
+    subprocess.run(cmd, shell=True, check=True)
 
 
 def convert_msmc_output(results_file, outfile, mutation_rate, generation_time):

--- a/workflows/n_t.snake
+++ b/workflows/n_t.snake
@@ -362,8 +362,9 @@ rule run_msmc:
                 chrms=chrm_list),
         rules.download_msmc.output,
     output:
-        expand(output_dir + "/inference/{{demog}}/msmc/{{dfes}}/{{annots}}/{{seeds}}/{{pops}}/{samps}.trees.multihep.txt.final.txt",
-            samps=num_sampled_genomes_msmc)
+        #expand(output_dir + "/inference/{{demog}}/msmc/{{dfes}}/{{annots}}/{{seeds}}/{{pops}}/{samps}.trees.multihep.txt.final.txt",
+        #            samps=num_sampled_genomes_msmc),
+        output_dir + "/inference/{demog}/msmc/{dfes}/{annots}/{seeds}/{pops}/{samps}.trees.multihep.txt.final.txt"
     threads: 8
     resources:
         mem_mb=24000
@@ -378,15 +379,17 @@ rule run_msmc:
                         )
         total_samples = demo_sample_size_dict[wildcards.demog][wildcards.pops]
         input_file_string = " ".join(inputs)
-        # TODO: get wildcards.samps to work so that num_sampled_genomes_msmc are run in parallel
         output_file_string = output_dir + f"/inference/{wildcards.demog}/msmc/{wildcards.dfes}/{wildcards.annots}/{wildcards.seeds}/{wildcards.pops}/"
-        msmc.run_msmc_estimate(input_file_string, output_file_string, msmc_exec, total_samples, num_sampled_genomes_msmc,
+        msmc.run_msmc_estimate(input_file_string, output_file_string, wildcards.samps, msmc_exec, total_samples,
             iterations=num_msmc_iterations, ncores=threads)
 
 
 rule convert_msmc:
     input:
-        rules.run_msmc.output
+        #rules.run_msmc.output,
+        #output_dir + "/inference/{demog}/msmc/{dfes}/{annots}/{seeds}/{pops}/{samps}.trees.multihep.txt.final.txt"
+        expand(output_dir + "/inference/{{demog}}/msmc/{{dfes}}/{{annots}}/{{seeds}}/{{pops}}/{samps}.trees.multihep.txt.final.txt",
+                    samps=num_sampled_genomes_msmc),
     output:
         output_dir + "/inference/{demog}/msmc/{dfes}/{annots}/{seeds}/{pops}/msmc_estimated_Ne.txt"
     run:


### PR DESCRIPTION
This allows msmc2 to run the different combinations of genome numbers, 2, 4, 6 ... etc, in parallel. Previous was a loop.