### PR TITLE
small edit, for extracting dfe-alpha output

### DIFF
--- a/workflows/dfe.snake
+++ b/workflows/dfe.snake
@@ -347,7 +347,7 @@ rule get_dfe_alpha_bestfits:
         output_dir + "/inference/{demog}/DFE-alpha/{dfes}/{annots}/{seeds}/{chrms}/pop{ids}/pop{ids}.DFE-alpha.bestfit"
     shell:
         """
-        cat {input} | awk -v id={wildcards.ids} 'BEGIN{{OFS="\\t"}}{{print "pop"id,$22,$10,$12}}' | sed '1ipop_id\\tlikelihood\\tb\\tEs' > {output}
+        cat {input} | awk -v id={wildcards.ids} 'BEGIN{{OFS="\\t"}}{{print "pop"id,$16,$10,$12}}' | sed '1ipop_id\\tlikelihood\\tb\\tEs' > {output}
         """
 
 # ###############################################################################


### PR DESCRIPTION
At some point we must have changed the dfe-alpha command without updating L350 for extracting the output. Here's an example output file:

```
cat results/inference/OutOfAfrica_3G09/DFE-alpha/Gamma_H17/ensembl_havana_104_exons/1845187043/chr21/pop0/nonneu/est_dfe.out
N1 100 N2 131 t2 106.0000 Nw 110.32 b 99.9999 Es -0.008198 f0 0.000000000 L -2599.8524

```