### PR TITLE
fix scaling of mean s for grapes

### DIFF
--- a/workflows/plots.py
+++ b/workflows/plots.py
@@ -278,7 +278,8 @@ def plot_all_dfe_results(input, output, mu, seq_len, nonneu_prop, pop_names=None
 
     grapes_shapes = [grapes_bestfits[i]['shape']
                      for i in range(len(grapes_bestfits))]
-    grapes_Es = [grapes_bestfits[i]['Es'] for i in range(len(grapes_bestfits))]
+    grapes_Ne = [grapes_bestfits[i]['theta'] / (4*mu) for i in range(len(grapes_bestfits))]
+    grapes_Es = [grapes_bestfits[i]['Es']/grapes_Ne[i] for i in range(len(grapes_bestfits))]
 
     fig = plt.figure(figsize=(6, 6), dpi=300)
 


### PR DESCRIPTION
Grapes outputs the population-scaled E(s) rather than E(s). This PR fixes that by calculating Ne from Grapes' theta output and rescale E(s) with the calculated Ne for plotting.

DFE inference results ran using tiny_config.yaml before and after this grapes E(s) scaling fix:

Before:
![dfe inference benchmark_old](https://user-images.githubusercontent.com/38679445/235717869-5ceb0900-2acf-46f6-8787-07153c4aecb4.png)

After:
![dfe inference benchmark_new](https://user-images.githubusercontent.com/38679445/235717883-95895a59-d05b-468c-a4c8-79e0c68f6326.png)
