### PR TITLE
diploSHIC preds

### DIFF
--- a/workflows/diploshic.snake
+++ b/workflows/diploshic.snake
@@ -152,6 +152,8 @@ rule train_classifier:
         "trained_model.json",
         "trained_model.weights.hdf5"
     run:
+        # cpu training below
+        shell('export CUDA_VISIBLE_DEVICES=\"\"')
         cmd = f"{diploSHIC_exec} train trainingSets/ trainingSets/ trained_model --epochs=10"
         shell(cmd)
 

--- a/workflows/diploshic_params.yaml
+++ b/workflows/diploshic_params.yaml
@@ -2,7 +2,7 @@
 trainSampleNumber: 10 #the number of simulation replicates we want to generate for each file in our training set
 testSampleNumber: 10 #the number of simulations to create for each file in the test set
 sampleSize: 10 #the number of individuals in our population sample
-numSites: 100_000 #total number of sites in our simulated window (i.e. S/HIC's subwindow size * 11)
+numSites: 110_000 #total number of sites in our simulated window (i.e. S/HIC's subwindow size * 11)
 u: 3.27e-9 #per-site mutation rate (used to calculate mean theta)
 gensPerYear: 10.0 #number of generations per year
 maxSoftSweepInitFreq: 0.1 #maximum initial selected frequency for soft sweeps

--- a/workflows/sweep_simulate.snake
+++ b/workflows/sweep_simulate.snake
@@ -436,7 +436,7 @@ module diploshic_workflow:
         "diploshic_params.yaml"
 
 
-#use rule * from diploshic_workflow as diploshic_*
+use rule * from diploshic_workflow as diploshic_*
 
 
 #### diploshic helpers ##########
@@ -506,11 +506,13 @@ vcf_outs = [file_prefix+".vcf" for file_prefix in neutral_outs_prefix + bgs_outs
 annot_outs = [output_dir + f'/simulated_data/sweeps/annot_overlap_{annot}_{chrom}_{config["num_windows"]}.tsv' for annot in annotation_list]
 anc_outs = [file_prefix+".diploshic.ancFile" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
 fv_outs = [file_prefix+".diploshic.fv" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
+pred_outs = [file_prefix+".diploshic.preds" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
 
 rule all:
     input:
        # rules.diploshic_all.input,
-        boundary_outs + trees_outs + stats_outs + vcf_outs + [output_dir + f'/simulated_data/sweeps/all_sims.stats.tsv', output_dir+f'/simulated_data/sweeps/rec_map_{chrom}_{config["num_windows"]}.tsv'] + annot_outs +anc_outs + fv_outs
+        boundary_outs + trees_outs + stats_outs + vcf_outs + [output_dir + f'/simulated_data/sweeps/all_sims.stats.tsv', output_dir+f'/simulated_data/sweeps/rec_map_{chrom}_{config["num_windows"]}.tsv'] + annot_outs +anc_outs + fv_outs + pred_outs
+    default_target: True
 
 rule write_rec:
     input:
@@ -781,7 +783,20 @@ rule diploshic_fvs:
    run:
         seq_len = tskit.load(input[0]).sequence_length
         cmd = f"diploSHIC fvecVcf haploid {input[1]} 1 {int(seq_len)} {output[0]} --ancFileName {input[2]}"    
-        shell(cmd)            
+        shell(cmd)    
+
+rule diploshic_pred:
+    input:
+        rules.diploshic_fvs.output,
+        rules.diploshic_all.output
+    output:
+        output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.diploshic.preds'
+    
+    run:
+        cmd = f"export CUDA_VISIBLE_DEVICES=\"\" && diploSHIC predict trained_model.json trained_model.weights.hdf5 {input[0]} {output[0]}" 
+        shell(cmd)   
+
+
 
 
 

--- a/workflows/sweep_simulate.snake
+++ b/workflows/sweep_simulate.snake
@@ -423,6 +423,47 @@ def dump_results(input, output, params_dict, target_pops, num_subwins=1):
     fh.close()
 
 
+
+#######################
+# Import diploshic rules
+#
+##########################
+
+module diploshic_workflow:
+    snakefile:
+        "diploshic.snake"
+    config:
+        "diploshic_params.yaml"
+
+
+#use rule * from diploshic_workflow as diploshic_*
+
+
+#### diploshic helpers ##########
+
+def write_diploshic_sampleToPopFile(ts, filename, key):
+    samp_dict = demo_sample_size_dict[key]
+    with open(filename, "w") as f:
+        count = 0
+        for pop in samp_dict:
+            for i in range(samp_dict[pop]):
+                f.write(f"tsk_{count}\t{pop}\n")
+                count += 1
+    f.close()
+
+
+def write_diploshic_files(ts_path, anc_path):
+    ts = tskit.load(ts_path)
+    seq = list("A" * int(ts.sequence_length))
+    with open(anc_path, "w") as f:
+        f.write(">1\n")
+        for v in ts.variants():
+            seq[int(v.site.position)] = v.alleles[0]
+        f.write(''.join(seq) + "\n")
+    f.close()
+
+
+
 # ###############################################################################
 # GENERAL RULES
 # ###############################################################################
@@ -463,10 +504,13 @@ trees_outs = [file_prefix+".trees" for file_prefix in neutral_outs_prefix + bgs_
 stats_outs = [file_prefix+".stats.tsv" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
 vcf_outs = [file_prefix+".vcf" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
 annot_outs = [output_dir + f'/simulated_data/sweeps/annot_overlap_{annot}_{chrom}_{config["num_windows"]}.tsv' for annot in annotation_list]
+anc_outs = [file_prefix+".diploshic.ancFile" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
+fv_outs = [file_prefix+".diploshic.fv" for file_prefix in neutral_outs_prefix + bgs_outs_prefix + sw_outs_prefix]
 
 rule all:
     input:
-        boundary_outs + trees_outs + stats_outs + vcf_outs + [output_dir + f'/simulated_data/sweeps/all_sims.stats.tsv', output_dir+f'/simulated_data/sweeps/rec_map_{chrom}_{config["num_windows"]}.tsv'] + annot_outs
+       # rules.diploshic_all.input,
+        boundary_outs + trees_outs + stats_outs + vcf_outs + [output_dir + f'/simulated_data/sweeps/all_sims.stats.tsv', output_dir+f'/simulated_data/sweeps/rec_map_{chrom}_{config["num_windows"]}.tsv'] + annot_outs +anc_outs + fv_outs
 
 rule write_rec:
     input:
@@ -646,7 +690,7 @@ rule get_stats:
     input: output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.trees'
     output:
         output_dir + "/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.stats.tsv", 
-        output_dir + "/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.vcf"
+        output_dir + "/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.vcf",
     resources: time=3000, mem_mb=2000
     run:
         target_pops = None
@@ -717,3 +761,27 @@ rule get_sw_stats:
     run:
         dump_results(input, output)
 """
+
+
+rule diploshic_files:
+   input: 
+       output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.trees'
+   output:
+       output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.diploshic.ancFile'
+   run:
+        write_diploshic_files(input[0], output[0])
+
+rule diploshic_fvs:
+   input: 
+       output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.trees',
+       output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.vcf',
+       rules.diploshic_files.output
+   output:
+       output_dir + '/simulated_data/sweeps/{middle}/sim_{chrom}_{left}_{right}.diploshic.fv'
+   run:
+        seq_len = tskit.load(input[0]).sequence_length
+        cmd = f"diploSHIC fvecVcf haploid {input[1]} 1 {int(seq_len)} {output[0]} --ancFileName {input[2]}"    
+        shell(cmd)            
+
+
+


### PR DESCRIPTION
this PR adds a diploshic sweep detection pipeline to the sweep workflow. 

there are a few steps here:

- in a `diploshic.snake` workflow we train a `diploshic` classifier under a 'vanilla' parameterization. 
- `diploshic` feature vectors are calculated from the vcf output of the sweep simulations
- `diploshic` prediction is performed using the trained model on the feature vector files

at the end of the day three new files are created within the individual simulation subdirs, e.g.

```
results/simulated_data/sweeps/sweep/OutOfAfrica_3G09/CEU/NA/NA/0.03/1/1501552846/
├── sim_chr1_121990000_126990000.diploshic.ancFile
├── sim_chr1_121990000_126990000.diploshic.fv
├── sim_chr1_121990000_126990000.diploshic.preds
```

the `.preds` file has the windowed predictions and their probabilities. the lines of those files look like e.g., 

```
chrom	classifiedWinStart	classifiedWinEnd	bigWinRange	predClass	prob(neutral)	prob(likedSoft)	prob(linkedHard)	prob(soft)	prob(hard)
1	450001	550000	1-1100000	neutral	0.974178	0.025754	0.000050	0.000012	0.000006
1	550001	650000	100001-1200000	neutral	0.976588	0.023380	0.000025	0.000004	0.000003
1	650001	750000	200001-1300000	neutral	0.942536	0.057163	0.000201	0.000010	0.000090
1	750001	850000	300001-1400000	neutral	0.976987	0.022642	0.000096	0.000037	0.000238

```
so the coordinates on the simulated chunk (NOT THE CHROMOSOME COORDS) are being output here, for instance the first big window was from bases 1-1100000, 11 subwindows are used, and the center most to be classified occurs from 450001	550000

@mufernando @nspope if you have a chance you check this out? Can this output be aggregated easily enough into what you already have?