### PR TITLE
update pipeline for new dfe with h-s relationship

### DIFF
--- a/workflows/stairway.py
+++ b/workflows/stairway.py
@@ -73,9 +73,10 @@ class StairwayPlotRunner(object):
             class_muts = {}
             for dfe in ts.metadata["stdpopsim"]["DFEs"]:
                 for mt in dfe["mutation_types"]:
-                    mid = mt["slim_mutation_type_id"]
-                    if not mid in class_muts:
-                        class_muts[mid] = "neutral" if mt["is_neutral"] else "non_neutral"
+                    mids = mt["slim_mutation_type_id"]
+                    for mid in mids:
+                        if not mid in class_muts:
+                            class_muts[mid] = "neutral" if mt["is_neutral"] else "non_neutral"
 
             site_class = np.empty(ts.num_sites, dtype=object)
 

--- a/workflows/ts2fs.py
+++ b/workflows/ts2fs.py
@@ -53,9 +53,10 @@ def _generate_fs_from_ts(ts_dict, pop_idx, mask_file, annot, species, max_haplos
         mut_types = {}
         for dfe in ts.metadata["stdpopsim"]["DFEs"]:
             for mt in dfe["mutation_types"]:
-                mid = mt["slim_mutation_type_id"]
-                if not mid in mut_types:
-                    mut_types[mid] = "neutral" if mt["is_neutral"] else "non_neutral"
+                mids = mt["slim_mutation_type_id"]
+                for mid in mids:
+                    if not mid in mut_types:
+                        mut_types[mid] = "neutral" if mt["is_neutral"] else "non_neutral"
 
         site_class = np.empty(ts.num_sites, dtype=object)
         for j, s in enumerate(ts.sites()):


### PR DESCRIPTION
For issue #106 

Changed one block of code in ts2fs.py, to deal with lists of mutation types within a DFE.

Tested by running sims with Mixed_K23 DFE (and also the Kim DFE), and running the dfe.snake pipeline. Example output below:

```
[chriscs@talapas-ln1 analysis2]$ cat results/inference/OutOfAfrica_3G09/dadi/Gamma_H17/ensembl_havana_104_exons/1845187043/pop1/pop1.dadi.neu.fs
41 unfolded
4603 1058 315 206 156 128 94 88 79 69 60 45 50 46 39 33 29 51 35 32 35 39 33 35 23 35 32 26 42 30 38 39 26 48 35 39 21 29 33 41 214
1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1

[chriscs@talapas-ln1 analysis2]$ cat results/inference/OutOfAfrica_3G09/dadi/Gamma_H17/ensembl_havana_104_exons/1845187043/pop1/pop1.dadi.nonneu.fs
41 unfolded
5235 1456 333 186 127 122 83 75 63 52 40 41 39 49 26 38 29 42 30 20 22 29 29 30 22 21 18 13 19 10 22 20 14 21 26 29 20 19 19 41 2168
1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1

[chriscs@talapas-ln1 analysis2]$ cat results/inference/OutOfAfrica_3G09/dadi/Mixed_K23/ensembl_havana_104_exons/1675701734/pop0/pop0.dadi.neu.fs
41 unfolded
2778 1871 897 550 356 254 235 178 173 151 123 120 88 87 73 90 63 65 62 40 57 43 37 23 29 49 46 29 32 39 35 41 22 37 42 29 23 34 34 35 9
1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1

[chriscs@talapas-ln1 analysis2]$ cat results/inference/OutOfAfrica_3G09/dadi/Mixed_K23/ensembl_havana_104_exons/1675701734/pop0/pop0.dadi.nonneu.fs
41 unfolded
4320 2623 1018 562 402 274 229 160 154 116 116 83 97 59 80 55 66 61 35 48 33 41 34 18 36 29 36 24 18 39 26 25 26 19 25 22 18 19 16 28 2216
1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1
```
